### PR TITLE
Refactor StableEventPool to use global sequence counter for event ordering

### DIFF
--- a/qns/simulator/stablepool.py
+++ b/qns/simulator/stablepool.py
@@ -32,7 +32,7 @@ class StableEventPool(object):
             return self.event == other.event and self.seq == other.seq
 
         def __lt__(self, other) -> bool:
-            return self.event < other.event or (
+            return self.event < other.event or (@
                 self.event == other.event and self.seq < other.seq
             )
 
@@ -62,8 +62,7 @@ class StableEventPool(object):
         self.te = te
         self.tc = ts
         self.event_list = []
-        self.insert_num = {}
-        self.pop_num = {}
+        self.seq = 0
 
     @property
     def current_time(self) -> Time:
@@ -84,11 +83,8 @@ class StableEventPool(object):
         if event.t < self.tc or event.t > self.te:
             return False
 
-        if event.t not in self.insert_num:
-            self.insert_num[event.t] = 0
-            self.pop_num[event.t] = 0
-        sevent = self.StableEvent(event, self.insert_num[event.t])
-        self.insert_num[event.t] += 1
+        sevent = self.StableEvent(event, self.seq)
+        self.seq += 1
         heapq.heappush(self.event_list, sevent)
         return True
 
@@ -103,10 +99,6 @@ class StableEventPool(object):
             sevent = heapq.heappop(self.event_list)
             event = sevent.event
             self.tc = event.t
-            self.pop_num[event.t] += 1
-            if self.pop_num[event.t] == self.insert_num[event.t]:
-                self.insert_num.pop(event.t, None)
-                self.pop_num.pop(event.t, None)
         except IndexError:
             event = None
             self.tc = self.te


### PR DESCRIPTION
Replace per-timestamp event counting with a global sequence counter to track insertion order, eliminating the need for dictionary-based tracking and cleanup logic in the add and next methods.