### PR TITLE
Add ClassicChannelEx for reliable packet delivery and ordering

### DIFF
--- a/qns/entity/cchannel/cchannel_ex.py
+++ b/qns/entity/cchannel/cchannel_ex.py
@@ -1,0 +1,109 @@
+#    SimQN: a discrete-event simulator for the quantum networks
+#    Copyright (C) 2021-2022 Lutong Chen, Jian Li, Kaiping Xue
+#    University of Science and Technology of China, USTC.
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+from typing import Any, List
+
+from qns.simulator.ts import Time
+from qns.entity.node.node import QNode
+from qns.models.delay.delay import DelayModel
+from qns.simulator.simulator import Simulator
+from qns.entity.cchannel.cchannel import *
+
+
+class ClassicChannelEx(ClassicChannel):
+    class param:
+        def __init__(self) -> None:
+            self._next_send_time: Time = Time(0)
+            self._last_recv_time: Time = Time(0)
+
+    def __init__(
+        self,
+        name: str = None,
+        node_list: List[QNode] = [],
+        bandwidth: int = 0,
+        delay: float | DelayModel = 0,
+        length: float | None = 0,
+        drop_rate: float = 0,
+        max_buffer_size: int = 0,
+    ):
+        super().__init__(
+            name, node_list, bandwidth, delay, length, drop_rate, max_buffer_size
+        )
+        self.reliable = True
+
+    def install(self, simulator: Simulator) -> None:
+        assert len(self.node_list) == 2
+        self.bidir_param = {
+            self.node_list[0]: self.param(),
+            self.node_list[1]: self.param(),
+        }
+        self.first_run = False
+        return super().install(simulator)
+
+    def send(self, packet: ClassicPacket, next_hop: QNode):
+
+        if next_hop not in self.node_list:
+            raise NextHopNotConnectionException
+
+        param = self.bidir_param[next_hop]
+
+        if self.bandwidth != 0:
+            if param._next_send_time <= self._simulator.current_time:
+                send_time = self._simulator.current_time
+            else:
+                send_time = param._next_send_time
+
+            if (
+                self.max_buffer_size != 0
+                and send_time
+                > self._simulator.current_time
+                + self._simulator.time(sec=self.max_buffer_size / self.bandwidth)
+            ):
+                # buffer is overflow
+                log.debug(f"cchannel {self}: drop packet {packet} due to overflow")
+                return
+
+            param._next_send_time = send_time + self._simulator.time(
+                sec=len(packet) / self.bandwidth
+            )
+        else:
+            send_time = self._simulator.current_time
+
+        # random drop
+        if self.reliable:
+            while get_rand() < self.drop_rate:
+                # 每丢包重发一次增加一个1-rtt
+                send_time += self._simulator.time(sec=self.delay_model.calculate())
+                send_time += self._simulator.time(sec=self.delay_model.calculate())
+        else:
+            if get_rand() < self.drop_rate:
+                log.debug(f"cchannel {self}: drop packet {packet} due to drop rate")
+                return
+
+        #  add delay
+        recv_time = send_time + self._simulator.time(sec=self.delay_model.calculate())
+
+        if self.reliable:
+            if recv_time < param._last_recv_time:
+                recv_time = param._last_recv_time
+
+            param._last_recv_time = recv_time
+
+        send_event = RecvClassicPacket(
+            recv_time, name=None, by=self, cchannel=self, packet=packet, dest=next_hop
+        )
+        self._simulator.add_event(send_event)

--- a/test/entity/test_cchannelex.py
+++ b/test/entity/test_cchannelex.py
@@ -1,0 +1,120 @@
+from qns.simulator.event import Event
+from qns.simulator import Simulator, func_to_event
+from qns.utils.log import *
+from qns.simulator.stablepool import StableEventPool
+from qns.entity import *
+from qns.entity.cchannel.cchannel_ex import ClassicChannelEx
+
+
+class AppS(Application):
+    def __init__(self, dst):
+        super().__init__()
+        self.dst = dst
+        self.i = 0
+        self.rate = 1.0
+
+    def start(self):
+        self.send()
+
+    def install(self, node, simulator: Simulator):
+        return super().install(node, simulator)
+
+    def send(self):
+        n: QNode = self.get_node()
+        c: ClassicChannelEx = n.get_cchannel(self.dst)
+
+        c.send(ClassicPacket(f"{self.i:02d}"), self.dst)
+        self.i += 1
+
+        self._simulator.add_event(
+            func_to_event(
+                self._simulator.tc + self._simulator.time(sec=1.0 / self.rate),
+                self.send,
+            )
+        )
+
+
+class AppR(Application):
+    def __init__(self):
+        super().__init__()
+        self.add_handler(self.recv)
+        self.recved = []
+        self.recved_time = []
+
+    def recv(self, node, event: Event):
+        packet: ClassicPacket = event.packet
+        # debug(f"{self.get_node().name} recv {packet.msg}")
+        self.recved.append(packet.msg)
+        self.recved_time.append(self._simulator.tc)
+
+
+def test(ex, tparam):
+    sim = Simulator(0, 10, pool_cls=StableEventPool)
+
+    install(sim)
+
+    n1 = QNode("n1")
+    n2 = QNode("n2")
+
+    global c12
+    if not ex:
+        c12 = ClassicChannel(
+            bandwidth=tparam[0],
+            drop_rate=tparam[1],
+            delay=tparam[2],
+            max_buffer_size=tparam[3],
+        )
+    else:
+        c12 = ClassicChannelEx(
+            bandwidth=tparam[0],
+            drop_rate=tparam[1],
+            delay=tparam[2],
+            max_buffer_size=tparam[3],
+        )
+        c12.reliable = True
+
+    n1.add_cchannel(c12)
+    n2.add_cchannel(c12)
+
+    s1 = AppS(n2)
+    r1 = AppR()
+    n1.add_apps(s1)
+    n2.add_apps(r1)
+
+    s2 = AppS(n1)
+    r2 = AppR()
+    n2.add_apps(s2)
+    n1.add_apps(r2)
+
+    n1.install(sim)
+    n2.install(sim)
+
+    s1.rate = 1
+    s2.rate = 1
+
+    s1.start()
+    s2.start()
+
+    sim.run()
+
+    print(f"n1->n2: {r1.recved}")
+    print(f"time:{r1.recved_time}")
+    print(f"\nn2->n1: {r2.recved}")
+    print(f"time:{r2.recved_time}")
+
+
+bidir = (2, 0, 0, 1)
+print("============================")
+print("bidir w/o Ex:")
+test(False, bidir)
+print("---------------")
+print("bidir w/ Ex:")
+test(True, bidir)
+
+reliable = (0, 0.5, 1, 0)
+print("============================")
+print("reliable w/o Ex:")
+test(False, reliable)
+print("---------------")
+print("reliable w/ Ex:")
+test(True, reliable)


### PR DESCRIPTION
Implement a reliable classic channel extension that extends ClassicChannel with automatic retransmission on packet drops, bidirectional parameter tracking for send/receive timing, and packet ordering guarantees to ensure recv_time respects the last received packet timestamp.

<img width="916" height="678" alt="image" src="https://github.com/user-attachments/assets/40509a12-f259-403a-83ce-39771f8e9ced" />
